### PR TITLE
Load Pipeline Fix

### DIFF
--- a/qt/GLSLEditorWidget.cpp
+++ b/qt/GLSLEditorWidget.cpp
@@ -56,16 +56,18 @@ QString GLSLEditorWidget::removeQtDefines(QString sourceCode)
         if (pos != -1)
         {
             sourceCode.remove(pos, defines[i].length());
+            
+            pos = sourceCode.indexOf('\n', pos);
+
+			// If the removal of QtDefine leaves empty lines
+			// remove the \n
+			if (pos != -1)
+			{
+				sourceCode.remove(pos, 1);
+			}
         }
 
-        pos = sourceCode.indexOf('\n');
-
-        if (pos != -1)
-        {
-            sourceCode.remove(pos, 1);
-        }
     }
-
 
     return sourceCode;
 }

--- a/qt/GLSLEditorWidget.cpp
+++ b/qt/GLSLEditorWidget.cpp
@@ -59,12 +59,12 @@ QString GLSLEditorWidget::removeQtDefines(QString sourceCode)
             
             pos = sourceCode.indexOf('\n', pos);
 
-			// If the removal of QtDefine leaves empty lines
-			// remove the \n
-			if (pos != -1)
-			{
-				sourceCode.remove(pos, 1);
-			}
+            // If the removal of QtDefine leaves empty lines
+            // remove the \n
+            if (pos != -1)
+            {
+                sourceCode.remove(pos, 1);
+            }
         }
 
     }


### PR DESCRIPTION
## The problem

When loading an .xml pipeline, the first three lines of each source file are merged together (end-lines are removed).

Screenshot that shows the problem: https://c1.staticflickr.com/1/566/31695088034_bc2e17061b_o.png

My system:
Ubuntu Linux 16.04 64bit
R9 380X with AMDGPU-PRO 16.50

## The cause

`removeQtDefines` is removing newlines regardless of whether qt defines were removed or not

## The solution

Only remove newlines when qt defines were removed, and start searching for newlines only from the position where the qt defines were found.