### PR TITLE
Keyboard shortcuts and Load/Save

### DIFF
--- a/qt/GLSLEditorWindow.cpp
+++ b/qt/GLSLEditorWindow.cpp
@@ -55,15 +55,6 @@ GLSLEditorWindow::GLSLEditorWindow(QGLShaderProgram* sProgram, QGLShaderProgram*
     connect(ui->actionSave_As_, SIGNAL(triggered()), this, SLOT(saveAs()));
     connect(ui->actionAbout, SIGNAL(triggered()), this, SLOT(about()));
     connect(ui->actionExit_Ctrl_X, SIGNAL(triggered()), this, SLOT(exitApplicationAction()));
-    
-    // Add keyboard shortcuts. They are connected automatically.
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(savePipelineAction()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Shift + Qt::Key_S), this, SLOT(savePipelineAsAction()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this, SLOT(loadPipeline()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_L), this, SLOT(loadFromFileAction()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_S), this, SLOT(saveToFileAction()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_Shift + Qt::Key_S), this, SLOT(saveAs()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_X), this, SLOT(exitApplicationAction()));
 
     //connect(textEdit->document(), &QTextDocument::contentsChanged,
     //	this, &MainWindow::documentWasModified);

--- a/qt/GLSLEditorWindow.cpp
+++ b/qt/GLSLEditorWindow.cpp
@@ -33,6 +33,7 @@
 #include <QSettings>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QShortcut>
 
 GLSLEditorWindow::GLSLEditorWindow(QGLShaderProgram* sProgram, QGLShaderProgram* dsProgram, QWidget *parent) :
     QMainWindow(parent), ui(new Ui::GLSLEditorWindow)
@@ -45,6 +46,7 @@ GLSLEditorWindow::GLSLEditorWindow(QGLShaderProgram* sProgram, QGLShaderProgram*
     readSettings();
 
     setupTabs();
+    
     connect(ui->actionSave_pipeline, SIGNAL(triggered()), this, SLOT(savePipelineAction()));
     connect(ui->actionSave_pipeline_As, SIGNAL(triggered()), this, SLOT(savePipelineAsAction()));
     connect(ui->actionLoad_pipeline, SIGNAL(triggered()), this, SLOT(loadPipeline()));
@@ -53,6 +55,15 @@ GLSLEditorWindow::GLSLEditorWindow(QGLShaderProgram* sProgram, QGLShaderProgram*
     connect(ui->actionSave_As_, SIGNAL(triggered()), this, SLOT(saveAs()));
     connect(ui->actionAbout, SIGNAL(triggered()), this, SLOT(about()));
     connect(ui->actionExit_Ctrl_X, SIGNAL(triggered()), this, SLOT(exitApplicationAction()));
+    
+    // Add keyboard shortcuts. They are connected automatically.
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(savePipelineAction()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Shift + Qt::Key_S), this, SLOT(savePipelineAsAction()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this, SLOT(loadPipeline()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_L), this, SLOT(loadFromFileAction()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_S), this, SLOT(saveToFileAction()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Alt + Qt::Key_Shift + Qt::Key_S), this, SLOT(saveAs()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_X), this, SLOT(exitApplicationAction()));
 
     //connect(textEdit->document(), &QTextDocument::contentsChanged,
     //	this, &MainWindow::documentWasModified);
@@ -403,7 +414,7 @@ bool GLSLEditorWindow::savePipelineAction()
 
 }
 
-bool GLSLEditorWindow::savePipeline(const QString& fileName)
+bool GLSLEditorWindow::savePipeline(QString& fileName)
 {
     GLSLEditorWidget* vertexEditor = static_cast<GLSLEditorWidget*>(ui->EditorTabWidget->widget(0));
     GLSLEditorWidget* geomEditor = static_cast<GLSLEditorWidget*>(ui->EditorTabWidget->widget(1));
@@ -411,6 +422,15 @@ bool GLSLEditorWindow::savePipeline(const QString& fileName)
     GLSLEditorWidget* R2TVertEditor = static_cast<GLSLEditorWidget*>(ui->EditorTabWidget->widget(3));
     GLSLEditorWidget* T2TFragEditor = static_cast<GLSLEditorWidget*>(ui->EditorTabWidget->widget(4));
 
+    // Make sure the fileName has the correct extension
+    if (!fileName.endsWith(QString(".xml"))) {
+        fileName.append(QString(".xml"));
+    }
+    
+    QString text = QString("Saving pipeline to %1").arg(fileName);
+    emit updateLog(text);
+    emit displayLog();
+    
     if (fileName.isEmpty())
     {
         pipelineFileName = QFileDialog::getSaveFileName(this,
@@ -488,7 +508,7 @@ bool GLSLEditorWindow::savePipeline(const QString& fileName)
 bool GLSLEditorWindow::loadPipeline()
 {
     QString fileName = QFileDialog::getOpenFileName(this,
-        tr("Save Pipeline"), "",
+        tr("Load Pipeline"), "",
         tr("XML file (*.xml);; All Files (*)"));
 
     if (!fileName.isEmpty())
@@ -536,6 +556,7 @@ bool GLSLEditorWindow::loadPipeline()
         //Close the document
         xmlDocument.close();
     }
+    pipelineFileName = fileName;
     return true;
 }
 

--- a/qt/GLSLEditorWindow.cpp
+++ b/qt/GLSLEditorWindow.cpp
@@ -55,6 +55,8 @@ GLSLEditorWindow::GLSLEditorWindow(QGLShaderProgram* sProgram, QGLShaderProgram*
     connect(ui->actionSave_As_, SIGNAL(triggered()), this, SLOT(saveAs()));
     connect(ui->actionAbout, SIGNAL(triggered()), this, SLOT(about()));
     connect(ui->actionExit_Ctrl_X, SIGNAL(triggered()), this, SLOT(exitApplicationAction()));
+    
+    new QShortcut(QKeySequence(Qt::Key_F3), this, SLOT(savePipelineAction()));
 
     //connect(textEdit->document(), &QTextDocument::contentsChanged,
     //	this, &MainWindow::documentWasModified);

--- a/qt/GLSLEditorWindow.h
+++ b/qt/GLSLEditorWindow.h
@@ -88,7 +88,7 @@ protected:
     void loadFile(QString &fileName);
     bool save();
     bool saveFile(const QString &fileName);
-    bool savePipeline(const QString &fileName);
+    bool savePipeline(QString &fileName);
     void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
 
 private:

--- a/qt/GLSLEditorWindow.ui
+++ b/qt/GLSLEditorWindow.ui
@@ -78,37 +78,37 @@
   </action>
   <action name="actionLoad">
    <property name="text">
-    <string>Load Shader (Ctrl-Alt-L)</string>
+    <string>Load Shader (Ctrl-L)</string>
    </property>
    <property name="toolTip">
     <string>&amp;Load (Ctrl-L)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+L</string>
+    <string>Ctrl+L</string>
    </property>
   </action>
   <action name="actionSave">
    <property name="text">
-    <string>Save Shader (Crtl-Alt-S)</string>
+    <string>Save Shader (Crtl-U)</string>
    </property>
    <property name="toolTip">
-    <string>&amp;Save (Crtl-Alt-S)</string>
+    <string>&amp;Save (Crtl-U)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+S</string>
+    <string>Ctrl+U</string>
    </property>
   </action>
   <action name="actionSave_As_">
    <property name="text">
-    <string>Save Shader As (Ctrl-Alt-Shift-S)</string>
+    <string>Save Shader As (Ctrl-Shift-U)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+Shift+S</string>
+    <string>Ctrl+Shift+U</string>
    </property>
   </action>
   <action name="actionExit_Ctrl_X">
    <property name="text">
-    <string>Exit (Ctrl-X)</string>
+    <string>Exit (Ctrl-Q)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
@@ -129,18 +129,18 @@
   </action>
   <action name="actionLoad_pipeline">
    <property name="text">
-    <string>Load pipeline (Ctrl-L)</string>
+    <string>Load pipeline (Ctrl-O)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+L</string>
+    <string>Ctrl+O</string>
    </property>
   </action>
   <action name="actionSave_pipeline_As">
    <property name="text">
-    <string>Save pipeline As (Ctrl-Shift-S)</string>
+    <string>Save pipeline As (Ctrl-E)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+S</string>
+    <string>Ctrl+E</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
## Keyboard shortcuts

Keyboard shortcuts were unresponsive on my system and on the Computing lab machines. The conversion from qt designer ui file to code seems to generate a String translation function instead of a key sequence.
I have added explicit keyboard handlers now that should make sure they are listened to properly.

## Saving extension

`.xml` is now added automatically to file extension

## Load then save

There was a bug in which if you load a pipeline, edit some files, and save, it would ask you to save to a new file instead of automatically saving to the loaded pipeline. This has been addressed.